### PR TITLE
Upgrade to Dropwizard 1.0.0

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -6,8 +6,8 @@ import sbtrelease._
 
 object Versions {
 
-  val dropwizard = "1.0.0-rc2"
-  val jackson = "2.7.3"
+  val dropwizard = "1.0.0"
+  val jackson = "2.7.5" // DW 1.0.0 uses jackson 2.7.6, but jackson-module-scala 2.7.5 is latest
   val mockito = "1.10.19"
   val scalaTest = "2.2.6"
 }

--- a/test/src/main/scala/com/datasift/dropwizard/scala/test/LiquibaseTest.scala
+++ b/test/src/main/scala/com/datasift/dropwizard/scala/test/LiquibaseTest.scala
@@ -3,7 +3,7 @@ package com.datasift.dropwizard.scala.test
 import java.util.Date
 
 import io.dropwizard.db.ManagedDataSource
-import io.dropwizard.migrations.CloseableLiquibase
+import io.dropwizard.migrations.{CloseableLiquibase, CloseableLiquibaseWithFileSystemMigrationsFile}
 
 import scala.util.{Failure, Try}
 
@@ -33,7 +33,7 @@ class LiquibaseTest(suite: BeforeAndAfterAllMulti,
   suite.beforeAll {
     _dataSource = Try(newDataSource)
     _liquibase = _dataSource
-      .flatMap(ds => Try(new CloseableLiquibase(ds, config.file)))
+      .flatMap(ds => Try(new CloseableLiquibaseWithFileSystemMigrationsFile(ds, config.file)))
 
     _liquibase.foreach(_.update(config.contexts.mkString(",")))
   }


### PR DESCRIPTION
Small change to one test as a DW class it was using has been marked `abstract` and there are now two concrete subclasses of it.

Both compilation and tests pass against Scala 2.10 & 2.11.