### PR TITLE
Add simple DSL for ResultSet mapping to object

### DIFF
--- a/jdbi/src/main/scala/com/datasift/dropwizard/scala/jdbi/ResultSetDSL.scala
+++ b/jdbi/src/main/scala/com/datasift/dropwizard/scala/jdbi/ResultSetDSL.scala
@@ -1,0 +1,32 @@
+
+package com.datasift.dropwizard.scala.jdbi
+
+import java.sql.{ResultSet, Timestamp}
+import java.util.Date
+
+
+/** Define some implicits to allow a more concise DSL using Tuples for extracting results from an SQL result set. */
+object ResultSetDSL {
+
+  implicit def getString(krs: (ResultSet, String)): String =
+    krs._1.getString(krs._2)
+
+  implicit def getInt(krs: (ResultSet, String)): Int =
+    krs._1.getInt(krs._2)
+
+  implicit def getLong(krs: (ResultSet, String)): Long =
+    krs._1.getLong(krs._2)
+
+  implicit def getBoolean(krs: (ResultSet, String)): Boolean =
+    krs._1.getBoolean(krs._2)
+
+  implicit def getBytes(krs: (ResultSet, String)): Array[Byte] =
+    krs._1.getBytes(krs._2)
+
+  implicit def getDate(krs: (ResultSet, String)): Date =
+    krs._1.getDate(krs._2)
+
+  implicit def getTimestamp(krs: (ResultSet, String)): Timestamp =
+    krs._1.getTimestamp(krs._2)
+}
+

--- a/jdbi/src/main/scala/com/datasift/dropwizard/scala/jdbi/SimpleMapper.scala
+++ b/jdbi/src/main/scala/com/datasift/dropwizard/scala/jdbi/SimpleMapper.scala
@@ -1,0 +1,22 @@
+
+package com.datasift.dropwizard.scala.jdbi
+
+import java.sql.ResultSet
+
+import org.skife.jdbi.v2.StatementContext
+import org.skife.jdbi.v2.tweak.ResultSetMapper
+
+
+/**
+  * A simple mapper that only depends on the result set
+  *
+  * Example -
+  *   SimpleMapper[(String, String)](r => (r.getString("firstname"), r.getString("lastname")))
+  *
+  * If you used with [[ResultSetDSL]] the above example can be further simplified -
+  *   SimpleMapper[(String, String)](r => (r -> "firstname", r -> "lastname"))
+  */
+class SimpleMapper[A](f: ResultSet => A) extends ResultSetMapper[A] {
+  def map(idx: Int, rs: ResultSet, ctx: StatementContext): A = f(rs)
+}
+

--- a/jdbi/src/main/scala/com/datasift/dropwizard/scala/jdbi/package.scala
+++ b/jdbi/src/main/scala/com/datasift/dropwizard/scala/jdbi/package.scala
@@ -17,17 +17,20 @@ package object jdbi {
     *
     *   dbi.open[DAO] to open a handle and attach a new sql object of the specified type to that handle
     *
-    *   dbi.daoFor[DAO] to create a new sql object which will obtain and release connections from this dbi instance, as it needs to,
-    *     and can, respectively
+    *   dbi.daoFor[DAO] to create a new sql object which will obtain and release connections from this dbi instance,
+    *   as it needs to, and can, respectively
     *
     *   When in scope, you can create transactions using for comprehension. For instance -
     *     {{{
-    *      for {
-    *       transaction <- dbi
-    *       dao <- transaction.dao[MyDao]
-    *     } yield {
-    *       dao.myFunction(v1, v2)
-    *     }
+    *       for { handle <- dbi.transaction
+    *            dao1   <- handle.attachable[Dao1]
+    *             ...
+    *            daoN   <- handle.attachable[DaoN] } yield {
+    *
+    *            dao1.some_function()
+    *            ...
+    *            daoN.some_other_function()
+    *      }
     *     }}}
     *
     * @param db the [[org.skife.jdbi.v2.DBI]] instance to wrap.


### PR DESCRIPTION
- Contains a new `SimpleMapper` that extends the jdbi `ResultSetMapper` aimed at simplifying object creation from `ResultSet`
- Contains a new `ResultSetDSL` that works on (`ResultSet`, `ColumnName`) tuples to create objects. See comments in code.