### PR TITLE
Scala 2.12

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,7 +1,6 @@
 libraryDependencies ++= Seq(
   "io.dropwizard" % "dropwizard-core" % Versions.dropwizard,
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % Versions.jackson,
-
   "io.dropwizard" % "dropwizard-client" % Versions.dropwizard % Test,
   "io.dropwizard" % "dropwizard-migrations" % Versions.dropwizard % Test,
   "mysql" % "mysql-connector-mxj" % "5.0.12" % Test

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -8,7 +8,7 @@ object Versions {
 
   val dropwizard = "1.0.5"
   val jackson = "2.8.4" // DW 1.0.0 uses jackson 2.7.6, but jackson-module-scala 2.7.5 is latest
-  val mockito = "1.10.19"
+  val mockito = "2.4.0"
   val scalaTest = "3.0.1"
 }
 

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -7,7 +7,7 @@ import sbtrelease._
 object Versions {
 
   val dropwizard = "1.0.5"
-  val jackson = "2.8.4" // DW 1.0.0 uses jackson 2.7.6, but jackson-module-scala 2.7.5 is latest
+  val jackson = "2.8.4"
   val mockito = "2.4.0"
   val scalaTest = "3.0.1"
 }

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -6,10 +6,10 @@ import sbtrelease._
 
 object Versions {
 
-  val dropwizard = "1.0.0"
-  val jackson = "2.7.5" // DW 1.0.0 uses jackson 2.7.6, but jackson-module-scala 2.7.5 is latest
+  val dropwizard = "1.0.5"
+  val jackson = "2.8.4" // DW 1.0.0 uses jackson 2.7.6, but jackson-module-scala 2.7.5 is latest
   val mockito = "1.10.19"
-  val scalaTest = "2.2.6"
+  val scalaTest = "3.0.1"
 }
 
 object CompileOptions {
@@ -44,7 +44,8 @@ object DropwizardScala extends Build {
       connection = "git://github.com/dropwizard/dropwizard-scala.git",
       devConnection = Option("git@github.com@:dropwizard/dropwizard-scala.git")
     )),
-    crossScalaVersions := Seq("2.10.6", "2.11.8"),
+    scalaVersion := "2.12.1",
+    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.1"),
     scalacOptions <++= scalaVersion.map(CompileOptions.scala),
     javacOptions ++= CompileOptions.java,
     resolvers in ThisBuild ++= Seq(
@@ -52,7 +53,7 @@ object DropwizardScala extends Build {
       "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
     ),
     libraryDependencies ++= Seq(
-      "org.log4s" %% "log4s" % "1.3.0",
+      "org.log4s" %% "log4s" % "1.3.4",
       "org.scalatest" %% "scalatest" % Versions.scalaTest % "test",
       "org.mockito" % "mockito-core" % Versions.mockito % "test"
     ),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.11
+sbt.version=0.13.13
 

--- a/test/build.sbt
+++ b/test/build.sbt
@@ -1,7 +1,7 @@
 libraryDependencies ++= Seq(
   "io.dropwizard" % "dropwizard-core" % Versions.dropwizard,
   "io.dropwizard" % "dropwizard-client" % Versions.dropwizard,
-  "org.scalatest" %% "scalatest" % "2.2.6",
+  "org.scalatest" %% "scalatest" % "3.0.1",
   "io.dropwizard" % "dropwizard-migrations" % Versions.dropwizard % "optional",
   "mysql" % "mysql-connector-mxj" % "5.0.12" % "optional"
 )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-1"
+version in ThisBuild := "1.0.5-1"


### PR DESCRIPTION
I updated many dependencies including dropwizard to allow for scala 2.12.x compilation.  Please note, when I ran the tests from master they did not pass (I'm not entirely sure the right way to run `ScalaApplicationSpecIT`).  I did not address that issue in this PR choosing instead to focus only on the scala 2.12.x upgrade.