### PR TITLE
Delay param conversion until Option parses as Some

### DIFF
--- a/jersey/src/main/scala/com/datasift/dropwizard/scala/jersey/inject/ScalaParamConverters.scala
+++ b/jersey/src/main/scala/com/datasift/dropwizard/scala/jersey/inject/ScalaParamConverters.scala
@@ -40,7 +40,7 @@ class OptionParamConverter[A](conv: ParamConverter[A])
   extends ParamConverter[Option[A]] {
 
   override def fromString(value: String): Option[A] = {
-    Option(conv.fromString(value))
+    Option(value).map(conv.fromString)
   }
 
   override def toString(value: Option[A]): String = {


### PR DESCRIPTION
Encountering Option query params that used to work on previous versions of dropwizard-scala no longer function properly - in particular, when the param was not present a `Some(null)` would be injected rather than a `None`. This was being caused by the converter code throwing exceptions when encountering null values, and does not happen on the cases currently tested by the library because the optional values are always a String.

Delaying the converter until after nulls have been wrapped by `Some/None` fixes the problem.