### PR TITLE
Upgrade to DW 1.3.1 and jackson 2.9.5

### DIFF
--- a/project/Project.scala
+++ b/project/Project.scala
@@ -6,8 +6,8 @@ import sbtrelease._
 
 object Versions {
 
-  val dropwizard = "1.1.0"
-  val jackson = "2.8.7"
+  val dropwizard = "1.3.1"
+  val jackson = "2.9.5"
   val mockito = "2.7.12"
   val scalaTest = "3.0.3"
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.0-3"
+version in ThisBuild := "1.3.1"


### PR DESCRIPTION
Upgrades Dropwizard to latest version 1.3.1 and its corresponding jackson version 2.9.5.
Bumps dropwizard-scala version to match Dropwizard version.
(built and ran tests after upgrade and things seem to work as expected).